### PR TITLE
Fix broken inventory examine

### DIFF
--- a/src/main/java/com/examinetooltip/ExamineTooltipOverlay.java
+++ b/src/main/java/com/examinetooltip/ExamineTooltipOverlay.java
@@ -31,7 +31,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetInfo.TO_CHILD;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
-import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -181,19 +180,6 @@ public class ExamineTooltipOverlay extends Overlay
 				}
 				break;
 
-			case ITEM:
-				int wId = examine.getWidgetId();
-				Widget widget = client.getWidget(TO_GROUP(wId), TO_CHILD(wId));
-				if (widget != null)
-				{
-					WidgetItem widgetItem = widget.getWidgetItem(examine.getActionParam());
-					if (widgetItem != null)
-					{
-						bounds = widgetItem.getCanvasBounds(false);
-					}
-				}
-				break;
-
 			case ITEM_INTERFACE:
 				bounds = findWidgetBounds(examine.getWidgetId(), examine.getActionParam());
 				break;
@@ -254,7 +240,7 @@ public class ExamineTooltipOverlay extends Overlay
 			return;
 		}
 
-		boolean isInterfaceExamine = type == ExamineType.ITEM || type == ExamineType.ITEM_INTERFACE;
+		boolean isInterfaceExamine = type == ExamineType.ITEM_INTERFACE;
 
 		int x = bounds.x;
 		int y = bounds.height + bounds.y;

--- a/src/main/java/com/examinetooltip/ExamineTooltipPlugin.java
+++ b/src/main/java/com/examinetooltip/ExamineTooltipPlugin.java
@@ -234,7 +234,10 @@ public class ExamineTooltipPlugin extends Plugin
 				}
 				else
 				{
-					type = ExamineType.ITEM_INTERFACE;
+					// Interfaces examines are no longer GAMEMESSAGE, so stop processing here
+					// https://github.com/runelite/runelite/blob/6c7ef87cb43d70daaa71fc1cba277eaafd86429f/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java#L126
+					// Previously: type = ExamineType.ITEM_INTERFACE;
+					return;
 				}
 				break;
 			default:
@@ -281,6 +284,7 @@ public class ExamineTooltipPlugin extends Plugin
 			return;
 		}
 
+		// Since we can't tell on the receiving end if an ITEM_EXAMINE is for interface items or ground items, allow an exception here.
 		if (pending.getType() == type || (type == ExamineType.ITEM_INTERFACE && pending.getType() == ExamineType.ITEM_GROUND))
 		{
 			pending.setTime(now);

--- a/src/main/java/com/examinetooltip/ExamineTooltipPlugin.java
+++ b/src/main/java/com/examinetooltip/ExamineTooltipPlugin.java
@@ -121,13 +121,6 @@ public class ExamineTooltipPlugin extends Plugin
 		{
 			switch (event.getMenuAction())
 			{
-				case EXAMINE_ITEM:
-					if (!config.showItemExamines())
-					{
-						return;
-					}
-					type = ExamineType.ITEM;
-					break;
 				case EXAMINE_ITEM_GROUND:
 					if (!config.showGroundItemExamines())
 					{
@@ -182,8 +175,8 @@ public class ExamineTooltipPlugin extends Plugin
 		}
 
 		int id = event.getId();
-		int actionParam = event.getActionParam();
-		int wId = event.getWidgetId();
+		int actionParam = event.getParam0(); // Action Param
+		int wId = event.getParam1(); // Widget ID
 
 		ExamineTextTime examine = new ExamineTextTime();
 		examine.setType(type);
@@ -221,7 +214,7 @@ public class ExamineTooltipPlugin extends Plugin
 				}
 				else
 				{
-					type = ExamineType.ITEM;
+					type = ExamineType.ITEM_INTERFACE;
 				}
 				break;
 			case OBJECT_EXAMINE:
@@ -288,7 +281,7 @@ public class ExamineTooltipPlugin extends Plugin
 			return;
 		}
 
-		if (pending.getType() == type || (type == ExamineType.ITEM && pending.getType() == ExamineType.ITEM_GROUND))
+		if (pending.getType() == type || (type == ExamineType.ITEM_INTERFACE && pending.getType() == ExamineType.ITEM_GROUND))
 		{
 			pending.setTime(now);
 			pending.setText(text);

--- a/src/main/java/com/examinetooltip/ExamineType.java
+++ b/src/main/java/com/examinetooltip/ExamineType.java
@@ -27,7 +27,6 @@ package com.examinetooltip;
 
 public enum ExamineType
 {
-	ITEM,
 	ITEM_GROUND,
 	ITEM_INTERFACE,
 	OBJECT,


### PR DESCRIPTION
Inventory now uses same system as other interfaces (CC_OPs) and chat messages seem to always be ITEM_EXAMINE rather than GAMEMESSAGE for non-inventory/ground examines.

Fixes #8 